### PR TITLE
new version of thrift will also generate `*seqid` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (client) {
     _.chain(client.prototype)
         .pairs()
         .each(function (pair) {
-            if(_.isFunction(pair[1]) && !(/send_.*/.test(pair[0]) || /recv_.*/.test(pair[0]))) {
+            if(_.isFunction(pair[1]) && !(/send_.*/.test(pair[0]) || /recv_.*/.test(pair[0]) || /seqid/.test(pair[0]))) {
                 client.prototype[pair[0]] = thunkify(pair[1]);
             }
         });


### PR DESCRIPTION
thrift will also generate codes like this:
`CalculatorClient.prototype.seqid = function() { return this._seqid; }
CalculatorClient.prototype.new_seqid = function() { return this._seqid += 1; }`
